### PR TITLE
fixed the psql-18 issue

### DIFF
--- a/databases/.env
+++ b/databases/.env
@@ -1,2 +1,1 @@
-SIZE=256mb
-VOLUMEPATH=../.volumes/databases
+SIZE=512mb

--- a/databases/.psql.env
+++ b/databases/.psql.env
@@ -1,0 +1,2 @@
+VOLUMEPATH=../.volumes/databases
+PGDATA=/var/lib/postgresql/data

--- a/databases/.sql.env
+++ b/databases/.sql.env
@@ -1,0 +1,1 @@
+VOLUMEPATH=../.volumes/databases

--- a/databases/postgres.yaml
+++ b/databases/postgres.yaml
@@ -2,6 +2,7 @@ services:
   postgres:
     container_name: postgres
     image: postgres
+    restart: unless-stopped
     shm_size: ${SIZE}
     volumes:
       - ${VOLUMEPATH}/psql:/var/lib/postgresql/data
@@ -10,17 +11,15 @@ services:
       POSTGRES_USER: "admin"
       POSTGRES_PASSWORD: "password@123"
     ports:
-      - 9032:5432
+      - 5432:5432
     networks:
       - postgres
-    restart: unless-stopped
     env_file:
-      - .env
+      - .psql.env
     deploy:
       resources:
         limits:
           memory: 256m
-
 networks:
   postgres:
     driver: bridge


### PR DESCRIPTION
This pull request fixes #15 . Since the upgrade to `psql-18`, you either have to explicitly include `PGDATA` in your environmental variables, or use `/var/lib/psq/18/data` instead as the default data volume.